### PR TITLE
Fix installation of bmadx subpackages

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,8 +6,8 @@ jobs:
   build:
     runs-on: ${{ matrix.os }}
     defaults:
-        run:
-          shell: bash
+      run:
+        shell: bash
     strategy:
       matrix:
         os: [ubuntu-latest]
@@ -20,16 +20,11 @@ jobs:
           channels: conda-forge
           activate-environment: bmadx
           environment-file: environment.yml
-          
+
       #- name: flake8
       #  shell: bash -l {0}
       #  run: |
       #    flake8 .
-
-      - name: Install Bmad-X
-        shell: bash -l {0}
-        run: |
-          pip install --no-dependencies .
 
       - name: Run Tests
         shell: bash -l {0}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,7 @@ jobs:
       run:
         shell: bash
     strategy:
+      fail-fast: false
       matrix:
         os: [ubuntu-latest]
         python-version: ["3.10", "3.11", "3.12"]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,11 @@ jobs:
       #  run: |
       #    flake8 .
 
+      - name: Show conda environment packages
+        shell: bash -l {0}
+        run: |
+          conda list
+
       - name: Ensure importability
         shell: bash -l {0}
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,12 @@ jobs:
       #  run: |
       #    flake8 .
 
+      - name: Ensure importability
+        shell: bash -l {0}
+        run: |
+          cd /
+          python -c "import bmadx"
+
       - name: Run Tests
         shell: bash -l {0}
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,7 @@ on: [push, pull_request]
 
 jobs:
   build:
+    name: Test ${{ matrix.os }} (${{ matrix.python-version }})
     runs-on: ${{ matrix.os }}
     defaults:
       run:
@@ -11,9 +12,10 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
+        python-version: ["3.10", "3.11", "3.12"]
     steps:
-      - uses: actions/checkout@v3
-      - uses: conda-incubator/setup-miniconda@v2
+      - uses: actions/checkout@v4
+      - uses: conda-incubator/setup-miniconda@v3
         with:
           python-version: ${{ matrix.python-version }}
           mamba-version: "*"

--- a/README.md
+++ b/README.md
@@ -1,35 +1,42 @@
 # Bmad-X
+
 Experimental Bmad Code transcribed in Python with Numba and Pytorch support.
 
-Installation
-============
-```shell
+## Installation
+
+```bash
 git clone https://github.com/bmad-sim/Bmad-X.git
+# pytorch-cuda on Windows or Linux.  Use environment-macos.yml for pytorch-cpu on MacOS.
 conda env create -f environment.yml
 conda activate bmadx
-pip install --no-dependencies -e .
 ```
 
-Cite
-============
+For a development installation of Bmad-X, run the following after creating the environment:
+
+```bash
+python -m pip install -e .
+```
+
+## Cite
+
 ```bibtex
 @inproceedings{gonzalez-aguilera:ipac2023-wepa065,
-	title        = {Towards fully differentiable accelerator modeling},
-	author       = {Gonzalez-Aguilera, J. and Kim, Y.-K. and Roussel, R. and Edelen, A. and Mayes, C.},
-	year         = 2023,
-	month        = {05},
-	booktitle    = {Proc. IPAC'23},
-	publisher    = {JACoW Publishing, Geneva, Switzerland},
-	series       = {IPAC'23 - 14th International Particle Accelerator Conference},
-	number       = 14,
-	pages        = {2797--2800},
-	doi          = {10.18429/JACoW-IPAC2023-WEPA065},
-	isbn         = {978-3-95450-231-8},
-	issn         = {2673-5490},
-	url          = {https://indico.jacow.org/event/41/contributions/2122},
-	%  booktitle = {Proc. 14th International Particle Accelerator Conference},
-	paper        = {WEPA065},
-	venue        = {Venice, Italy},
-	language     = {English}
+ title        = {Towards fully differentiable accelerator modeling},
+ author       = {Gonzalez-Aguilera, J. and Kim, Y.-K. and Roussel, R. and Edelen, A. and Mayes, C.},
+ year         = 2023,
+ month        = {05},
+ booktitle    = {Proc. IPAC'23},
+ publisher    = {JACoW Publishing, Geneva, Switzerland},
+ series       = {IPAC'23 - 14th International Particle Accelerator Conference},
+ number       = 14,
+ pages        = {2797--2800},
+ doi          = {10.18429/JACoW-IPAC2023-WEPA065},
+ isbn         = {978-3-95450-231-8},
+ issn         = {2673-5490},
+ url          = {https://indico.jacow.org/event/41/contributions/2122},
+ %  booktitle = {Proc. 14th International Particle Accelerator Conference},
+ paper        = {WEPA065},
+ venue        = {Venice, Italy},
+ language     = {English}
 }
 ```

--- a/environment-macos.yml
+++ b/environment-macos.yml
@@ -2,13 +2,11 @@ name: bmadx
 channels:
   - conda-forge
   - pytorch
-  - nvidia
 dependencies:
   - python >=3.10
   - ipython
   - ipykernel
   - pytorch
-  - pytorch-cuda >=11.7
   - numpy
   - matplotlib
   - pytest

--- a/environment.yml
+++ b/environment.yml
@@ -5,7 +5,7 @@ channels:
   - nvidia
   - defaults
 dependencies:
-  - python=3.10
+  - python >=3.10
   - ipython
   - ipykernel
   - pytorch
@@ -21,4 +21,3 @@ dependencies:
   - bmad
   - pytao
   - distgen
-  

--- a/setup.py
+++ b/setup.py
@@ -4,16 +4,18 @@ with open("README.md", "r", encoding="utf-8") as fh:
     long_description = fh.read()
 
 setuptools.setup(
-    name='bmadx',
-    version='0.0.1',
-    author='J.P. Gonzalez-Aguilera',
-    description='Experimental Bmad code transcribed in Python with Numba and Pytorch support',
+    name="bmadx",
+    version="0.0.1",
+    author="J.P. Gonzalez-Aguilera",
+    description="Experimental Bmad code transcribed in Python with Numba and Pytorch support",
     long_description=long_description,
     long_description_content_type="text/markdown",
-    url='https://github.com/bmad-sim/Bmad-X',
-    project_urls = {
-        "Bug Tracker": "https://github.com/bmad-sim/Bmad-X/issues"
-    },
-    license='Apache-2.0',
-    packages=['bmadx']
+    url="https://github.com/bmad-sim/Bmad-X",
+    project_urls={"Bug Tracker": "https://github.com/bmad-sim/Bmad-X/issues"},
+    license="Apache-2.0",
+    packages=[
+        package 
+        for package in setuptools.find_packages(".")
+        if package not in {"test"}
+    ],
 )


### PR DESCRIPTION
## Context

For context, I'd like to get Bmad-X on conda-forge to make it easier to install [pyDFCSR](https://github.com/jy-tang/pyDFCSR). (specifically https://github.com/jy-tang/pyDFCSR/pull/4)

## Issue

In the `main` branch, `setup.py` only installs the `bmadx` package and none of its subpackages.
This is not a problem when using a development installation (`pip install -e .`) because the source code files are used in-place. However, when a regular installation is performed (`pip install .`), it neglects to copy the bmadx subpackages (e.g., `bmadx.tracking_routines`).

## The fix

This PR includes a fix but also a bit of package/CI maintenance. I hope you don't mind...

* Use `setuptools.find_packages` to enumerate the subpackages (excluding the test suite)
* Added an `environment-macos.yml` file, since cuda is unavailable on MacOS and I wanted to test the installation on my MacBook
* Unpinned Python 3.10 as I believe it shouldn't be required. It's (in my opinion) better to let conda decide what's compatible
* Updated the `README` to include notes about other platforms and the fact that you don't have to do `pip install` any longer (as it's now included as a step in `environment.yml`; see the `pip` lines there)
* Updated GitHub Actions to verify importability (non dev install) and test multiple Python versions

It appears that some of the tests are failing, but I believe it's unrelated to my packaging changes here as most others pass:

<details>
<summary>Test failures</summary>

```
 =========================== short test summary info ============================
FAILED tests/test_bmadx_torch.py::TestBmadxTorch::test_crab_cavity - assert False
 +  where False = <built-in method allclose of type object at 0x7f8f5c57ac20>(tensor([ 0.0026,  0.0030, -0.0032, -0.0010,  0.0020, -0.0020],\n       dtype=torch.float64), tensor([ 0.0026,  0.0030, -0.0032, -0.0010,  0.0020, -0.0020],\n       dtype=torch.float64), atol=0, rtol=1e-14)
 +    where <built-in method allclose of type object at 0x7f8f5c57ac20> = torch.allclose
FAILED tests/test_bmadx_torch.py::TestBmadxTorch::test_crab_cavity_offset - assert False
 +  where False = <built-in method allclose of type object at 0x7f8f5c57ac20>(tensor([ 0.0026,  0.0030, -0.0032, -0.0010,  0.0020, -0.0020],\n       dtype=torch.float64), tensor([ 0.0026,  0.0030, -0.0032, -0.0010,  0.0020, -0.0020],\n       dtype=torch.float64), atol=0, rtol=1e-14)
 +    where <built-in method allclose of type object at 0x7f8f5c57ac20> = torch.allclose
FAILED tests/test_bmadx_torch.py::TestBmadxTorch::test_crab_cavity_tilt - assert False
 +  where False = <built-in method allclose of type object at 0x7f8f5c57ac20>(tensor([ 0.0026,  0.0030, -0.0032, -0.0010,  0.0020, -0.0020],\n       dtype=torch.float64), tensor([ 0.0026,  0.0030, -0.0032, -0.0010,  0.0020, -0.0020],\n       dtype=torch.float64), atol=0, rtol=1e-14)
 +    where <built-in method allclose of type object at 0x7f8f5c57ac20> = torch.allclose
=================== 3 failed, 11 passed, 1 warning in 1.80s ====================
```

</details>